### PR TITLE
Port library

### DIFF
--- a/src/main/scala/Channel.scala
+++ b/src/main/scala/Channel.scala
@@ -116,7 +116,7 @@ trait QueueInChannel[+A](q: LTQueue[A]) extends AsyncInChannel[A] {
 
   override def receive()(implicit timeout: Duration) = {
     if (!timeout.isFinite) {
-      q.take()
+      q.take().nn
     } else {
       val ret = q.poll(timeout.length, timeout.unit)
       if (ret == null) {
@@ -128,14 +128,14 @@ trait QueueInChannel[+A](q: LTQueue[A]) extends AsyncInChannel[A] {
 
   override def poll() = q.poll() match {
     case null => None
-    case head => Some(head)
+    case head => Some(head.nn)
   }
 
   override def enqueue(i: (Map[ProcVar[_], (_) => Process], List[() => Process], In[AsyncInChannel[Any], Any, Any => Process])): Unit = pendingInProcesses.add(i)
 
   override def dequeue() = pendingInProcesses.poll() match {
     case null => None
-    case head => Some(head)
+    case head => Some(head.nn)
   }
 
 }

--- a/src/main/scala/SchedulingQueue.scala
+++ b/src/main/scala/SchedulingQueue.scala
@@ -32,7 +32,7 @@ class SchedulingQueue[E] {
   }
 
   def dequeue(): Option[E] = {
-    try { Some(queue.take()) } catch {
+    try { Some(queue.take().nn) } catch {
         case e: InterruptedException =>
           None
       }


### PR DESCRIPTION
Total LOC changed: 4

**Java classification** | 2
`java.util.concurrent.LinkedTransferQueue.take` | IM
.nn count: 2
Documentation: doesn't specify nullability but based on the code, should throw error in the null case.

**Limitation of flow type inference** | 2
```
x match {
  case null => null
  case f => f // should never be null
}
```